### PR TITLE
Update Makefile to push to AWS Elastic Container Registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,22 @@
 #!/usr/bin/make
 
+IMG = nginx-quic-qns
+REG = public.ecr.aws/nginx
+$(eval REPO=$(REG)/$(IMG))
+
 default:
-	@echo "valid targets: build push"
+	@echo "valid targets: login build push all"
+
+login:
+	aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin $(REG)
 
 build:
-	docker build --pull --no-cache -t nginx/nginx-quic-qns:latest -f Dockerfile .
+	docker build --pull --no-cache -t $(IMG):latest -f Dockerfile .
 
 push:
-	docker push nginx/nginx-quic-qns:latest
+	docker tag $(IMG):latest $(REPO):latest
+	docker push $(REPO):latest
 
-.PHONY: default build push
+all: login build push
+
+.PHONY: all


### PR DESCRIPTION
Makefile has been updated to push the docker image to the AWS Elastic Container Registry.