### PR TITLE
Change the builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM martenseemann/quic-network-simulator-endpoint:latest AS builder
+FROM ubuntu:latest AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update


### PR DESCRIPTION
When use the old builder image to build a docker image with the Dockerfile will get error, and got a notice:"note: module requires Go 1.19" because the "martenseemann/quic-network-simulator-endpoint:latest" was used  "ubuntu:20.04" image to build, and latest go version in ubuntu:20.04 software repository is 1.18 not 1.19. So just change the builder image into ubuntu:latest or ubuntu:22.04 is OK.