### PR TITLE
Update Dockerfile to use latest Golang for BoringSSL build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,12 @@ FROM martenseemann/quic-network-simulator-endpoint:latest AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN apt-get install -qy mercurial build-essential libpcre3 libpcre3-dev zlib1g zlib1g-dev curl git cmake ninja-build golang gnutls-bin iptables
+RUN apt-get install -qy mercurial build-essential libpcre3 libpcre3-dev zlib1g zlib1g-dev curl git cmake ninja-build gnutls-bin iptables
 
 RUN useradd nginx
+
+COPY --from=golang:latest /usr/local/go/ /usr/local/go/
+ENV PATH="/usr/local/go/bin:${PATH}"
 
 RUN git clone --depth=1 https://github.com/google/boringssl.git
 


### PR DESCRIPTION
The nginx-quic build requires BoringSSL, which needs Go version 1.19 or higher for its compilation. However, the docker image
'martenseemann/quic-network-simulator-endpoint' is based on Ubuntu 20.04, which installs Go version 1.13 from its package repository. This commit updates the Dockerfile to fetch and use latest Golang version during the build process, ensuring compatibility with BoringSSL requirements.