### PR TITLE
Fix nginx start and tweak CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   push_build: false
+  trigger_build: false
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
@@ -45,6 +46,9 @@ jobs:
         run: |
           if [ "${{ env.commit_id }}" != "${{ env.latest_image_commit }}" ]; then
             echo "Commit IDs are different. Triggering build."
+            echo "trigger_build=true" >> $GITHUB_ENV
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "Running under workflow_dispatch. Triggering build."
             echo "trigger_build=true" >> $GITHUB_ENV
           else
             echo "Commit IDs are the same. No build needed."

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM martenseemann/quic-network-simulator-endpoint:latest AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN apt-get install -qy build-essential libpcre3 libpcre3-dev zlib1g zlib1g-dev curl git cmake ninja-build gnutls-bin iptables
+RUN apt-get install -qy build-essential libpcre2-dev zlib1g zlib1g-dev curl git cmake ninja-build gnutls-bin iptables
 
 RUN useradd nginx
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -31,7 +31,7 @@ http {
 
         http3_hq on;
 
-        add_header Alt-Svc 'hq-29=":443"';
+        add_header Alt-Svc 'h3=":443"; ma=86400';
         location / {
             root /www;
         }

--- a/nginx.conf.http3
+++ b/nginx.conf.http3
@@ -28,7 +28,7 @@ http {
         listen *:443 quic reuseport;
         listen [::]:443 ssl;
         listen [::]:443 quic reuseport;
-        add_header Alt-Svc 'h3-29=":443"';
+        add_header Alt-Svc 'h3=":443"; ma=86400';
         location / {
             root /www;
         }

--- a/nginx.conf.nodebug
+++ b/nginx.conf.nodebug
@@ -31,7 +31,7 @@ http {
 
         http3_hq on;
 
-        add_header Alt-Svc 'hq-29=":443"';
+        add_header Alt-Svc 'h3=":443"; ma=86400';
         location / {
             root /www;
         }

--- a/nginx.conf.retry
+++ b/nginx.conf.retry
@@ -31,7 +31,7 @@ http {
 
         http3_hq on;
 
-        add_header Alt-Svc 'hq-29=":443"';
+        add_header Alt-Svc 'h3=":443"; ma=86400';
         location / {
             root /www;
         }


### PR DESCRIPTION
### Proposed changes

This PR fixes nginx binary startup as seen on the current image:

```
server  | >>> Starting nginx server...
server  | /usr/sbin/nginx: error while loading shared libraries: libpcre.so.3: cannot open shared object file: No such file or directory
server  | >>> Parameters:
server  | >>> Test case: handshake
server  | /usr/sbin/nginx: error while loading shared libraries: libpcre.so.3: cannot open shared object file: No such file or directory
server exited with code 127
```

Additionally, it adds a change to CI to trigger image rebuilds on `workflow_dispatch` events even if the commit id on the main nginx repo is the same as the currently built image.